### PR TITLE
podspell script: set output encoding from locale LC_CTYPE

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history {{$dist->name}}
 
 {{$NEXT}}
+	- podspell script: set output encoding from locale CTYPE (DOLMEN)
 
 1.15      2014-02-28
 	- Convert to strict mode of File::ShareDir::ProjectDistDir (KENTNL)

--- a/bin/podspell
+++ b/bin/podspell
@@ -5,6 +5,20 @@ use Pod::Spell;
 
 # VERSION
 
+if ($] ge '5.008001') {
+  # Try to get the encoding from the locale
+  my $encoding = eval {
+    require POSIX;
+    POSIX::setlocale(POSIX::LC_CTYPE(), '');
+    require I18N::Langinfo;
+    I18N::Langinfo::langinfo(I18N::Langinfo::CODESET())
+  };
+
+  if ($encoding) {
+    binmode(STDOUT, ":encoding($encoding)");
+  }
+}
+
 if(@ARGV) {  # iterate over files, sending to STDOUT
   foreach my $x (@ARGV) {
     Pod::Spell->new->parse_from_file($x, '-');


### PR DESCRIPTION
Fix the `podspell` to use the encoding from the locale.

*Signed-off-by: Olivier Mengué <dolmen@cpan.org>*